### PR TITLE
Added TTL cache and methods to calculate distances from routes. Google Geocoder problems when using an API Key solved.

### DIFF
--- a/GMap.NET.Core/GMap.NET.MapProviders/Bing/BingMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/Bing/BingMapProvider.cs
@@ -184,7 +184,7 @@ namespace GMap.NET.MapProviders
                #region -- try get sesion key --
                if(!string.IsNullOrEmpty(key))
                {
-                  string keyResponse = GMaps.Instance.UseUrlCache ? Cache.Instance.GetContent("BingLoggingServiceV1" + key, CacheType.UrlCache, TimeSpan.FromHours(8)) : string.Empty;
+                  string keyResponse = GMaps.Instance.UseUrlCache ? Cache.Instance.GetContent("BingLoggingServiceV1" + key, CacheType.UrlCache, TimeSpan.FromHours(GMapProvider.TTLCache)) : string.Empty;
 
                   if(string.IsNullOrEmpty(keyResponse))
                   {

--- a/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
@@ -200,6 +200,11 @@ namespace GMap.NET.MapProviders
     public abstract class GMapProvider
     {
         /// <summary>
+        /// Time to live of cache, in hours. Default: 240 (10 days).
+        /// </summary>
+        public static int TTLCache = 240;
+
+        /// <summary>
         /// unique provider id
         /// </summary>
         public abstract Guid Id

--- a/GMap.NET.Core/GMap.NET.MapProviders/Google/GoogleMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/Google/GoogleMapProvider.cs
@@ -96,7 +96,7 @@ namespace GMap.NET.MapProviders
                 string url = string.Format("https://maps.{0}/maps/api/js?client=google-maps-lite&amp;libraries=search&amp;language=en&amp;region=", ServerAPIs);
                 try
                 {
-                    string html = GMaps.Instance.UseUrlCache ? Cache.Instance.GetContent(url, CacheType.UrlCache, TimeSpan.FromHours(8)) : string.Empty;
+                    string html = GMaps.Instance.UseUrlCache ? Cache.Instance.GetContent(url, CacheType.UrlCache, TimeSpan.FromHours(GMapProvider.TTLCache)) : string.Empty;
 
                     if (string.IsNullOrEmpty(html))
                     {
@@ -1360,8 +1360,9 @@ namespace GMap.NET.MapProviders
             return status;
         }
 
-        static readonly string ReverseGeocoderUrlFormat = "http://maps.{0}/maps/api/geocode/xml?latlng={1},{2}&language={3}&sensor=false";
-        static readonly string GeocoderUrlFormat = "http://maps.{0}/maps/api/geocode/xml?address={1}&language={2}&sensor=false";
+        // Note: Use of API Key requires https's queries.
+        static readonly string ReverseGeocoderUrlFormat = "https://maps.{0}/maps/api/geocode/xml?latlng={1},{2}&language={3}&sensor=false";
+        static readonly string GeocoderUrlFormat = "https://maps.{0}/maps/api/geocode/xml?address={1}&language={2}&sensor=false";
 
         #endregion
 

--- a/GMap.NET.Core/GMap.NET/MapRoute.cs
+++ b/GMap.NET.Core/GMap.NET/MapRoute.cs
@@ -47,6 +47,72 @@ namespace GMap.NET
          }
       }
 
+
+      /// <summary>
+      /// Gets the minimum distance (in mts) from the route to a point. Gets null if total points of route are less than 2.
+      /// </summary>
+      /// <param name="point">Point to calculate distance.</param>
+      /// <returns>Distance in meters.</returns>
+      public double? DistanceTo(PointLatLng point)
+      {
+          // Minimun of two elements required to compare.
+          if (Points.Count >= 2)
+          {
+              // First element as the min.
+              double min = DistanceToLinealRoute(Points[0], Points[1], point);
+
+              // From 2.
+              for (int i = 2; i < Points.Count; i++)
+              {
+                  double distance = DistanceToLinealRoute(Points[i - 1], Points[i], point);
+
+                  if (distance < min)
+                      min = distance;
+              }
+
+              return min;
+          }
+
+          return null;
+      }
+
+
+      /// <summary>
+      /// Gets the distance (in mts) between the nearest point of a lineal route (of two points), and a point.
+      /// </summary>
+      /// <param name="start">Start point of lineal route.</param>
+      /// <param name="to">End point of lineal route.</param>
+      /// <param name="point">Point to calculate distance.</param>
+      /// <returns>Distance in meters.</returns>
+      public static double DistanceToLinealRoute(PointLatLng start, PointLatLng to, PointLatLng point)
+      {
+          // Lineal function formula => y = mx+b (y is lat, x is lng).
+          // Member m.
+          double m = (start.Lat - to.Lat) / (start.Lng - to.Lng);
+
+          // Obtain of b => b = y-mx
+          double b = -(m * start.Lng - start.Lat);
+
+          // Possible points of Lat and Lng based on formula replacement (formulaLat and formulaLng).
+          // Lat = m*Lng+b
+          double formulaLat = m*point.Lng + b;
+
+          // Lat = m*Lng+b => (Lat-b)/m=Lng 
+          double formulaLng = (point.Lat-b)/m;
+
+          // Possibles distances: One from the given point.Lat, and other from the point.Lng.
+          double distance1 = GMapProviders.EmptyProvider.Projection.
+                             GetDistance(new PointLatLng(point.Lat, formulaLng), point);
+          double distance2 = GMapProviders.EmptyProvider.Projection.
+                             GetDistance(new PointLatLng(formulaLat, point.Lng), point);
+
+          // Min of the distances.
+          double distance = distance1 <= distance2 ? distance1 : distance2;
+
+          // To mts.
+          return distance*1000;
+      }
+
       /// <summary>
       /// route end point
       /// </summary>


### PR DESCRIPTION
_Preliminary note: sorry for my english._

Now, changes:
- Added methods to calculate distances from a route to a point.
- Added time to live cache (BingMapProvider and GoogleMapProvider).
- Fixed problem of geocoder of GoogleMapProvider, when an API Key is used.
