### PR TITLE
OpenStreetMapProviderBase - set virtual keyword to RoutingProvider methods

### DIFF
--- a/GMap.NET.Core/GMap.NET.MapProviders/Bing/BingMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/Bing/BingMapProvider.cs
@@ -371,13 +371,13 @@ namespace GMap.NET.MapProviders
 
       #region RoutingProvider
 
-      public MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int Zoom)
+      public MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int zoom)
       {
          string tooltip;
          int numLevels;
          int zoomFactor;
          MapRoute ret = null;
-         List<PointLatLng> points = GetRoutePoints(MakeRouteUrl(start, end, LanguageStr, avoidHighways, walkingMode), Zoom, out tooltip, out numLevels, out zoomFactor);
+         List<PointLatLng> points = GetRoutePoints(MakeRouteUrl(start, end, LanguageStr, avoidHighways, walkingMode), zoom, out tooltip, out numLevels, out zoomFactor);
          if(points != null)
          {
             ret = new MapRoute(points, tooltip);
@@ -385,13 +385,13 @@ namespace GMap.NET.MapProviders
          return ret;
       }
 
-      public MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int Zoom)
+      public MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int zoom)
       {
          string tooltip;
          int numLevels;
          int zoomFactor;
          MapRoute ret = null;
-         List<PointLatLng> points = GetRoutePoints(MakeRouteUrl(start, end, LanguageStr, avoidHighways, walkingMode), Zoom, out tooltip, out numLevels, out zoomFactor);
+         List<PointLatLng> points = GetRoutePoints(MakeRouteUrl(start, end, LanguageStr, avoidHighways, walkingMode), zoom, out tooltip, out numLevels, out zoomFactor);
          if(points != null)
          {
             ret = new MapRoute(points, tooltip);

--- a/GMap.NET.Core/GMap.NET.MapProviders/Etc/CloudMadeMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/Etc/CloudMadeMapProvider.cs
@@ -71,7 +71,7 @@ namespace GMap.NET.MapProviders
 
       #region RoutingProvider Members
 
-      public MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int Zoom)
+      public MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int zoom)
       {
          List<PointLatLng> points = GetRoutePoints(MakeRoutingUrl(start, end, walkingMode ? TravelTypeFoot : TravelTypeMotorCar, LanguageStr, "km"));
          MapRoute route = points != null ? new MapRoute(points, walkingMode ? WalkingStr : DrivingStr) : null;
@@ -85,9 +85,9 @@ namespace GMap.NET.MapProviders
       /// <param name="end"></param>
       /// <param name="avoidHighways"></param>
       /// <param name="walkingMode"></param>
-      /// <param name="Zoom"></param>
+      /// <param name="zoom"></param>
       /// <returns></returns>
-      public MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int Zoom)
+      public MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int zoom)
       {
          throw new NotImplementedException();
       }

--- a/GMap.NET.Core/GMap.NET.MapProviders/Google/GoogleMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/Google/GoogleMapProvider.cs
@@ -218,13 +218,13 @@ namespace GMap.NET.MapProviders
 
         #region RoutingProvider Members
 
-        public MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int Zoom)
+        public MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int zoom)
         {
             string tooltip;
             int numLevels;
             int zoomFactor;
             MapRoute ret = null;
-            List<PointLatLng> points = GetRoutePoints(MakeRouteUrl(start, end, LanguageStr, avoidHighways, walkingMode), Zoom, out tooltip, out numLevels, out zoomFactor);
+            List<PointLatLng> points = GetRoutePoints(MakeRouteUrl(start, end, LanguageStr, avoidHighways, walkingMode), zoom, out tooltip, out numLevels, out zoomFactor);
             if (points != null)
             {
                 ret = new MapRoute(points, tooltip);
@@ -232,13 +232,13 @@ namespace GMap.NET.MapProviders
             return ret;
         }
 
-        public MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int Zoom)
+        public MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int zoom)
         {
             string tooltip;
             int numLevels;
             int zoomFactor;
             MapRoute ret = null;
-            List<PointLatLng> points = GetRoutePoints(MakeRouteUrl(start, end, LanguageStr, avoidHighways, walkingMode), Zoom, out tooltip, out numLevels, out zoomFactor);
+            List<PointLatLng> points = GetRoutePoints(MakeRouteUrl(start, end, LanguageStr, avoidHighways, walkingMode), zoom, out tooltip, out numLevels, out zoomFactor);
             if (points != null)
             {
                 ret = new MapRoute(points, tooltip);

--- a/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapProvider.cs
@@ -64,7 +64,7 @@ namespace GMap.NET.MapProviders
 
       #region GMapRoutingProvider Members
 
-      public MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int Zoom)
+      public virtual MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int zoom)
       {
          List<PointLatLng> points = GetRoutePoints(MakeRoutingUrl(start, end, walkingMode ? TravelTypeFoot : TravelTypeMotorCar));
          MapRoute route = points != null ? new MapRoute(points, walkingMode ? WalkingStr : DrivingStr) : null;
@@ -78,9 +78,9 @@ namespace GMap.NET.MapProviders
       /// <param name="end"></param>
       /// <param name="avoidHighways"></param>
       /// <param name="walkingMode"></param>
-      /// <param name="Zoom"></param>
+      /// <param name="zoom"></param>
       /// <returns></returns>
-      public MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int Zoom)
+      public virtual MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int zoom)
       {
          throw new NotImplementedException("use GetRoute(PointLatLng start, PointLatLng end...");
       }

--- a/GMap.NET.Core/GMap.NET/RoutingProvider.cs
+++ b/GMap.NET.Core/GMap.NET/RoutingProvider.cs
@@ -9,11 +9,11 @@ namespace GMap.NET
       /// <summary>
       /// get route between two points
       /// </summary>
-      MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int Zoom);
+      MapRoute GetRoute(PointLatLng start, PointLatLng end, bool avoidHighways, bool walkingMode, int zoom);
 
       /// <summary>
       /// get route between two points
       /// </summary>
-      MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int Zoom);
+      MapRoute GetRoute(string start, string end, bool avoidHighways, bool walkingMode, int zoom);
    }
 }


### PR DESCRIPTION
OpenStreetMapProviderBase - set virtual keyword to RoutingProvider implementing methods because of need for overriding in inherited classes. For implementing other routing providers than yournavigation.org. 

Fixing wrong case of character 'Z' in method GetRoute() parameter Zoom.