### PR TITLE
OpenStreetMap connection issue.

### DIFF
--- a/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapProvider.cs
@@ -517,9 +517,9 @@ namespace GMap.NET.MapProviders
          return ret;
       }
 
-      static readonly string ReverseGeocoderUrlFormat = "http://nominatim.openstreetmap.org/reverse?format=xml&lat={0}&lon={1}&zoom=18&addressdetails=1";
-      static readonly string GeocoderUrlFormat = "http://nominatim.openstreetmap.org/search?q={0}&format=xml";
-      static readonly string GeocoderDetailedUrlFormat = "http://nominatim.openstreetmap.org/search?street={0}&city={1}&county={2}&state={3}&country={4}&postalcode={5}&format=xml";
+      static readonly string ReverseGeocoderUrlFormat = "https://nominatim.openstreetmap.org/reverse?format=xml&lat={0}&lon={1}&zoom=18&addressdetails=1";
+      static readonly string GeocoderUrlFormat = "https://nominatim.openstreetmap.org/search?q={0}&format=xml";
+      static readonly string GeocoderDetailedUrlFormat = "https://nominatim.openstreetmap.org/search?street={0}&city={1}&county={2}&state={3}&country={4}&postalcode={5}&format=xml";
 
       #endregion
 
@@ -590,6 +590,6 @@ namespace GMap.NET.MapProviders
          return string.Format(UrlFormat, letter, zoom, pos.X, pos.Y);
       }
 
-      static readonly string UrlFormat = "http://{0}.tile.openstreetmap.org/{1}/{2}/{3}.png";
+      static readonly string UrlFormat = "https://{0}.tile.openstreetmap.org/{1}/{2}/{3}.png";
    }
 }

--- a/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapProvider.cs
@@ -14,7 +14,9 @@ namespace GMap.NET.MapProviders
       public OpenStreetMapProviderBase()
       {
          MaxZoom = null;
-         RefererUrl = "http://www.openstreetmap.org/";
+         //Tile usage policy of openstreetmap (https://operations.osmfoundation.org/policies/tiles/) define as optional and providing referer 
+         //only if one valid available. by providing http://www.openstreetmap.org/ a 418 error is given by the server.
+         //RefererUrl = "http://www.openstreetmap.org/";
          Copyright = string.Format("© OpenStreetMap - Map data ©{0} OpenStreetMap", DateTime.Today.Year);
       }
 


### PR DESCRIPTION
The request for tiles were done for OpenStreetMap via http connection.
These requests were returning 403 error. The switch has been made on https.
After that switch a 418 error is provided. Which is due to the referrer field with an arbitrary default value.
the Tile Usage Policy of OpenStreetMap specify to providing one only if known.