### PR TITLE
fix bug

### DIFF
--- a/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcher.cs
+++ b/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcher.cs
@@ -135,6 +135,11 @@ using System.Drawing;
 
       void worker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
       {
+         if (IsDisposed)
+         {
+            ((BackgroundWorker)sender).CancelAsync();            
+            return;
+         }
          if(ShowCompleteMessage)
          {
             if(!e.Cancelled)


### PR DESCRIPTION
while loading the card into the cache if you try to interrupt the download (Esc) ->

ObjectDisposedException: Access to the liquidated object is not possible.
Object Name: "TilePrefetcher".


This exception was originally thrown in this call stack:
	System.Windows.Forms.Control.CreateHandle()
	System.Windows.Forms.Form.CreateHandle()
	System.Windows.Forms.Control.Handle.get()
	System.Windows.Forms.Control.GetSafeHandle(System.Windows.Forms.IWin32Window)
	System.Windows.Forms.MessageBox.ShowCore(System.Windows.Forms.IWin32Window, string, string, System.Windows.Forms.MessageBoxButtons, System.Windows.Forms.MessageBoxIcon, System.Windows.Forms.MessageBoxDefaultButton, System.Windows.Forms.MessageBoxOptions, bool)
	System.Windows.Forms.MessageBox.Show(System.Windows.Forms.IWin32Window, string)
    GMap.NET.TilePrefetcher.worker_RunWorkerCompleted(object, System.ComponentModel.RunWorkerCompletedEventArgs) в TilePrefetcher.cs
	System.ComponentModel.BackgroundWorker.OnRunWorkerCompleted(System.ComponentModel.RunWorkerCompletedEventArgs)

tracert: -------------------------------------------------------------------------------------------------


   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at System.Windows.Forms.Control.InvokeMarshaledCallbackDo(ThreadMethodEntry tme)
   at System.Windows.Forms.Control.InvokeMarshaledCallbackHelper(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Windows.Forms.Control.InvokeMarshaledCallback(ThreadMethodEntry tme)
   at System.Windows.Forms.Control.InvokeMarshaledCallbacks()
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.DebuggableCallback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
   at System.Windows.Forms.SafeNativeMethods.MessageBox(HandleRef hWnd, String text, String caption, Int32 type)
   at System.Windows.Forms.MessageBox.ShowCore(IWin32Window owner, String text, String caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, MessageBoxOptions options, Boolean showHelp)
   at System.Windows.Forms.MessageBox.Show(String text, String caption, MessageBoxButtons buttons)
   at Demo.WindowsForms.MainForm.button11_Click(Object sender, EventArgs e) in C:\Users\user\source\repos\greatmaps\Demo.WindowsForms\Forms\MainForm.cs:line 2037
   at System.Windows.Forms.Control.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnMouseUp(MouseEventArgs mevent)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ButtonBase.WndProc(Message& m)
   at System.Windows.Forms.Button.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.DebuggableCallback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
   at System.Windows.Forms.UnsafeNativeMethods.DispatchMessageW(MSG& msg)
   at System.Windows.Forms.Application.ComponentManager.System.Windows.Forms.UnsafeNativeMethods.IMsoComponentManager.FPushMessageLoop(IntPtr dwComponentID, Int32 reason, Int32 pvLoopData)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoopInner(Int32 reason, ApplicationContext context)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoop(Int32 reason, ApplicationContext context)
   at Demo.WindowsForms.Program.Main() in C:\Users\user\source\repos\greatmaps\Demo.WindowsForms\Source\Program.cs:line 23