### PR TITLE
New SwissTopo map provider+projection

### DIFF
--- a/GMap.NET.Core/GMap.NET.Core.csproj
+++ b/GMap.NET.Core/GMap.NET.Core.csproj
@@ -236,6 +236,7 @@
     <Compile Include="GMap.NET.MapProviders\Czech\CzechTuristWinterMapProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\Etc\CloudMadeMapProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\Etc\SwedenMapProvider.cs" />
+    <Compile Include="GMap.NET.MapProviders\Etc\SwissTopoProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\Etc\WikiMapiaMapProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\CzechOld\CzechHistoryMapProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\CzechOld\CzechHybridMapProvider.cs" />
@@ -294,6 +295,7 @@
     <Compile Include="GMap.NET.Projections\SWEREF99_TMProjection.cs" />
     <Compile Include="GMap.NET.Projections\MapsLTReliefProjection.cs" />
     <Compile Include="GMap.NET.Projections\PlateCarreeProjectionDarbAe.cs" />
+    <Compile Include="GMap.NET.Projections\SwissTopoProjection.cs" />
     <Compile Include="GMap.NET\GDirections.cs" />
     <Compile Include="GMap.NET\DirectionsProvider.cs" />
     <Compile Include="GMap.NET\GeocodingProvider.cs" />

--- a/GMap.NET.Core/GMap.NET.MapProviders/Etc/SwissTopoProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/Etc/SwissTopoProvider.cs
@@ -1,0 +1,71 @@
+﻿namespace GMap.NET.MapProviders
+{
+    using System;
+    using GMap.NET.Projections;
+
+    public class SwissTopoProvider : GMapProvider
+    {
+        private readonly Guid _id = new Guid("0F1F1EC5-B297-4B5B-8EB4-27AA403D1860");
+        private readonly string _name = "SwissTopo";
+        private readonly Random _randomGen;
+
+        public override Guid Id
+        {
+            get { return _id; }
+        }
+
+        public static readonly SwissTopoProvider Instance;
+
+        SwissTopoProvider()
+        {
+            // Terms of use: https://api3.geo.admin.ch/api/terms_of_use.html
+
+            MaxZoom = null;
+            _randomGen = new Random();
+        }
+
+        private GMapProvider[] _overlays;
+
+        string MakeTileImageUrl(GPoint pos, int zoom)
+        {
+            int serverMaxDigits = 10; // from wmts[0-9].geo.admin.ch 
+            var serverDigit = _randomGen.Next() % serverMaxDigits;
+            var layerName = "ch.swisstopo.pixelkarte-farbe";
+            var tileMatrixSet = "2056";
+            var time = "current";
+
+            // <Scheme>://<ServerName>/<ProtocoleVersion>/<LayerName>/<Stylename>/<Time>/<TileMatrixSet>/<TileSetId=Zoom>/<TileRow>/<TileCol>.<FormatExtension>
+            var formattedUrl = $"https://wmts{serverDigit}.geo.admin.ch/1.0.0/{layerName}/default/{time}/{tileMatrixSet}/{zoom}/{pos.X}/{pos.Y}.jpeg";
+
+            return formattedUrl;
+        }
+
+        static SwissTopoProvider()
+        {
+            Instance = new SwissTopoProvider();
+        }
+
+        #region GMapProvider Members
+
+        public override string Name => _name;
+        public override PureProjection Projection => SwissTopoProjection.Instance;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (_overlays == null) _overlays = new GMapProvider[] {this};
+                return _overlays;
+            }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+    }
+}

--- a/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
@@ -49,20 +49,61 @@ namespace GMap.NET.MapProviders
 
         public static readonly EmptyProvider EmptyProvider = EmptyProvider.Instance;
 
-        public static readonly OpenStreetMapProvider OpenStreetMap = OpenStreetMapProvider.Instance;
-
-        public static readonly OpenStreet4UMapProvider OpenStreet4UMap = OpenStreet4UMapProvider.Instance;
-
-        public static readonly OpenCycleMapProvider OpenCycleMap = OpenCycleMapProvider.Instance;
+        public static readonly ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_Map = ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider.Instance;
+        public static readonly ArcGIS_Imagery_World_2D_MapProvider ArcGIS_Imagery_World_2D_Map = ArcGIS_Imagery_World_2D_MapProvider.Instance;
+        public static readonly ArcGIS_ShadedRelief_World_2D_MapProvider ArcGIS_ShadedRelief_World_2D_Map = ArcGIS_ShadedRelief_World_2D_MapProvider.Instance;
+        public static readonly ArcGIS_StreetMap_World_2D_MapProvider ArcGIS_StreetMap_World_2D_Map = ArcGIS_StreetMap_World_2D_MapProvider.Instance;
+        public static readonly ArcGIS_Topo_US_2D_MapProvider ArcGIS_Topo_US_2D_Map = ArcGIS_Topo_US_2D_MapProvider.Instance;
+        public static readonly ArcGIS_World_Physical_MapProvider ArcGIS_World_Physical_Map = ArcGIS_World_Physical_MapProvider.Instance;
+        public static readonly ArcGIS_World_Shaded_Relief_MapProvider ArcGIS_World_Shaded_Relief_Map = ArcGIS_World_Shaded_Relief_MapProvider.Instance;
+        public static readonly ArcGIS_World_Street_MapProvider ArcGIS_World_Street_Map = ArcGIS_World_Street_MapProvider.Instance;
+        public static readonly ArcGIS_World_Terrain_Base_MapProvider ArcGIS_World_Terrain_Base_Map = ArcGIS_World_Terrain_Base_MapProvider.Instance;
+        public static readonly ArcGIS_World_Topo_MapProvider ArcGIS_World_Topo_Map = ArcGIS_World_Topo_MapProvider.Instance;
+        public static readonly BingHybridMapProvider BingHybridMap = BingHybridMapProvider.Instance;
+        public static readonly BingMapProvider BingMap = BingMapProvider.Instance;
+        public static readonly BingOSMapProvider BingOSMap = BingOSMapProvider.Instance;
+        public static readonly BingSatelliteMapProvider BingSatelliteMap = BingSatelliteMapProvider.Instance;
+        public static readonly CloudMadeMapProvider CloudMadeMap = CloudMadeMapProvider.Instance;
+        public static readonly CzechGeographicMapProvider CzechGeographicMap = CzechGeographicMapProvider.Instance;
+        public static readonly CzechHistoryMapProvider CzechHistoryMap = CzechHistoryMapProvider.Instance;
+        public static readonly CzechHistoryMapProviderOld CzechHistoryOldMap = CzechHistoryMapProviderOld.Instance;
+        public static readonly CzechHybridMapProvider CzechHybridMap = CzechHybridMapProvider.Instance;
+        public static readonly CzechHybridMapProviderOld CzechHybridOldMap = CzechHybridMapProviderOld.Instance;
+        public static readonly CzechMapProvider CzechMap = CzechMapProvider.Instance;
+        public static readonly CzechMapProviderOld CzechOldMap = CzechMapProviderOld.Instance;
+        public static readonly CzechSatelliteMapProvider CzechSatelliteMap = CzechSatelliteMapProvider.Instance;
+        public static readonly CzechSatelliteMapProviderOld CzechSatelliteOldMap = CzechSatelliteMapProviderOld.Instance;
+        public static readonly CzechTuristMapProvider CzechTuristMap = CzechTuristMapProvider.Instance;
+        public static readonly CzechTuristMapProviderOld CzechTuristOldMap = CzechTuristMapProviderOld.Instance;
+        public static readonly CzechTuristWinterMapProvider CzechTuristWinterMap = CzechTuristWinterMapProvider.Instance;
+        public static readonly GoogleChinaHybridMapProvider GoogleChinaHybridMap = GoogleChinaHybridMapProvider.Instance;
+        public static readonly GoogleChinaMapProvider GoogleChinaMap = GoogleChinaMapProvider.Instance;
+        public static readonly GoogleChinaSatelliteMapProvider GoogleChinaSatelliteMap = GoogleChinaSatelliteMapProvider.Instance;
+        public static readonly GoogleChinaTerrainMapProvider GoogleChinaTerrainMap = GoogleChinaTerrainMapProvider.Instance;
+        public static readonly GoogleHybridMapProvider GoogleHybridMap = GoogleHybridMapProvider.Instance;
+        public static readonly GoogleKoreaHybridMapProvider GoogleKoreaHybridMap = GoogleKoreaHybridMapProvider.Instance;
+        public static readonly GoogleKoreaMapProvider GoogleKoreaMap = GoogleKoreaMapProvider.Instance;
+        public static readonly GoogleKoreaSatelliteMapProvider GoogleKoreaSatelliteMap = GoogleKoreaSatelliteMapProvider.Instance;
+        public static readonly GoogleMapProvider GoogleMap = GoogleMapProvider.Instance;
+        public static readonly GoogleSatelliteMapProvider GoogleSatelliteMap = GoogleSatelliteMapProvider.Instance;
+        public static readonly GoogleTerrainMapProvider GoogleTerrainMap = GoogleTerrainMapProvider.Instance;
+        public static readonly LatviaMapProvider LatviaMap = LatviaMapProvider.Instance;
+        public static readonly Lithuania3dMapProvider Lithuania3dMap = Lithuania3dMapProvider.Instance;
+        public static readonly LithuaniaHybridMapProvider LithuaniaHybridMap = LithuaniaHybridMapProvider.Instance;
+        public static readonly LithuaniaHybridOldMapProvider LithuaniaHybridOldMap = LithuaniaHybridOldMapProvider.Instance;
+        public static readonly LithuaniaMapProvider LithuaniaMap = LithuaniaMapProvider.Instance;
+        public static readonly LithuaniaOrtoFotoMapProvider LithuaniaOrtoFotoMap = LithuaniaOrtoFotoMapProvider.Instance;
+        public static readonly LithuaniaOrtoFotoOldMapProvider LithuaniaOrtoFotoOldMap = LithuaniaOrtoFotoOldMapProvider.Instance;
+        public static readonly LithuaniaReliefMapProvider LithuaniaReliefMap = LithuaniaReliefMapProvider.Instance;
+        public static readonly LithuaniaTOP50 LithuaniaTOP50Map = LithuaniaTOP50.Instance;
+        public static readonly MapBenderWMSProvider MapBenderWMSdemoMap = MapBenderWMSProvider.Instance;
+        public static readonly NearHybridMapProvider NearHybridMap = NearHybridMapProvider.Instance;
+        public static readonly NearMapProvider NearMap = NearMapProvider.Instance;
+        public static readonly NearSatelliteMapProvider NearSatelliteMap = NearSatelliteMapProvider.Instance;
         public static readonly OpenCycleLandscapeMapProvider OpenCycleLandscapeMap = OpenCycleLandscapeMapProvider.Instance;
+        public static readonly OpenCycleMapProvider OpenCycleMap = OpenCycleMapProvider.Instance;
         public static readonly OpenCycleTransportMapProvider OpenCycleTransportMap = OpenCycleTransportMapProvider.Instance;
-
-        public static readonly OpenStreetMapQuestProvider OpenStreetMapQuest = OpenStreetMapQuestProvider.Instance;
-        public static readonly OpenStreetMapQuestSatteliteProvider OpenStreetMapQuestSattelite = OpenStreetMapQuestSatteliteProvider.Instance;
-        public static readonly OpenStreetMapQuestHybridProvider OpenStreetMapQuestHybrid = OpenStreetMapQuestHybridProvider.Instance;
-
         public static readonly OpenSeaMapHybridProvider OpenSeaMapHybrid = OpenSeaMapHybridProvider.Instance;
-
 #if OpenStreetOsm
       public static readonly OpenStreetOsmProvider OpenStreetOsm = OpenStreetOsmProvider.Instance;
 #endif
@@ -71,91 +112,26 @@ namespace GMap.NET.MapProviders
       public static readonly OpenStreetMapSurferProvider OpenStreetMapSurfer = OpenStreetMapSurferProvider.Instance;
       public static readonly OpenStreetMapSurferTerrainProvider OpenStreetMapSurferTerrain = OpenStreetMapSurferTerrainProvider.Instance;
 #endif
-        public static readonly WikiMapiaMapProvider WikiMapiaMap = WikiMapiaMapProvider.Instance;
-
-        public static readonly BingMapProvider BingMap = BingMapProvider.Instance;
-        public static readonly BingSatelliteMapProvider BingSatelliteMap = BingSatelliteMapProvider.Instance;
-        public static readonly BingHybridMapProvider BingHybridMap = BingHybridMapProvider.Instance;
-        public static readonly BingOSMapProvider BingOSMap = BingOSMapProvider.Instance;
-
-        public static readonly YahooMapProvider YahooMap = YahooMapProvider.Instance;
-        public static readonly YahooSatelliteMapProvider YahooSatelliteMap = YahooSatelliteMapProvider.Instance;
-        public static readonly YahooHybridMapProvider YahooHybridMap = YahooHybridMapProvider.Instance;
-
-        public static readonly GoogleMapProvider GoogleMap = GoogleMapProvider.Instance;
-        public static readonly GoogleSatelliteMapProvider GoogleSatelliteMap = GoogleSatelliteMapProvider.Instance;
-        public static readonly GoogleHybridMapProvider GoogleHybridMap = GoogleHybridMapProvider.Instance;
-        public static readonly GoogleTerrainMapProvider GoogleTerrainMap = GoogleTerrainMapProvider.Instance;
-
-        public static readonly GoogleChinaMapProvider GoogleChinaMap = GoogleChinaMapProvider.Instance;
-        public static readonly GoogleChinaSatelliteMapProvider GoogleChinaSatelliteMap = GoogleChinaSatelliteMapProvider.Instance;
-        public static readonly GoogleChinaHybridMapProvider GoogleChinaHybridMap = GoogleChinaHybridMapProvider.Instance;
-        public static readonly GoogleChinaTerrainMapProvider GoogleChinaTerrainMap = GoogleChinaTerrainMapProvider.Instance;
-
-        public static readonly GoogleKoreaMapProvider GoogleKoreaMap = GoogleKoreaMapProvider.Instance;
-        public static readonly GoogleKoreaSatelliteMapProvider GoogleKoreaSatelliteMap = GoogleKoreaSatelliteMapProvider.Instance;
-        public static readonly GoogleKoreaHybridMapProvider GoogleKoreaHybridMap = GoogleKoreaHybridMapProvider.Instance;
-
-        public static readonly NearMapProvider NearMap = NearMapProvider.Instance;
-        public static readonly NearSatelliteMapProvider NearSatelliteMap = NearSatelliteMapProvider.Instance;
-        public static readonly NearHybridMapProvider NearHybridMap = NearHybridMapProvider.Instance;
-
+        public static readonly OpenStreet4UMapProvider OpenStreet4UMap = OpenStreet4UMapProvider.Instance;
+        public static readonly OpenStreetMapProvider OpenStreetMap = OpenStreetMapProvider.Instance;
+        public static readonly OpenStreetMapQuestHybridProvider OpenStreetMapQuestHybrid = OpenStreetMapQuestHybridProvider.Instance;
+        public static readonly OpenStreetMapQuestProvider OpenStreetMapQuest = OpenStreetMapQuestProvider.Instance;
+        public static readonly OpenStreetMapQuestSatteliteProvider OpenStreetMapQuestSattelite = OpenStreetMapQuestSatteliteProvider.Instance;
+        public static readonly OviHybridMapProvider OviHybridMap = OviHybridMapProvider.Instance;
         public static readonly OviMapProvider OviMap = OviMapProvider.Instance;
         public static readonly OviSatelliteMapProvider OviSatelliteMap = OviSatelliteMapProvider.Instance;
-        public static readonly OviHybridMapProvider OviHybridMap = OviHybridMapProvider.Instance;
         public static readonly OviTerrainMapProvider OviTerrainMap = OviTerrainMapProvider.Instance;
-
+        public static readonly SpainMapProvider SpainMap = SpainMapProvider.Instance;
+        public static readonly SwedenMapProvider SwedenMap = SwedenMapProvider.Instance;
+        public static readonly SwissTopoProvider SwissMap = SwissTopoProvider.Instance;
+        public static readonly TurkeyMapProvider TurkeyMap = TurkeyMapProvider.Instance;
+        public static readonly WikiMapiaMapProvider WikiMapiaMap = WikiMapiaMapProvider.Instance;
+        public static readonly YahooHybridMapProvider YahooHybridMap = YahooHybridMapProvider.Instance;
+        public static readonly YahooMapProvider YahooMap = YahooMapProvider.Instance;
+        public static readonly YahooSatelliteMapProvider YahooSatelliteMap = YahooSatelliteMapProvider.Instance;
+        public static readonly YandexHybridMapProvider YandexHybridMap = YandexHybridMapProvider.Instance;
         public static readonly YandexMapProvider YandexMap = YandexMapProvider.Instance;
         public static readonly YandexSatelliteMapProvider YandexSatelliteMap = YandexSatelliteMapProvider.Instance;
-        public static readonly YandexHybridMapProvider YandexHybridMap = YandexHybridMapProvider.Instance;
-
-        public static readonly LithuaniaMapProvider LithuaniaMap = LithuaniaMapProvider.Instance;
-        public static readonly LithuaniaReliefMapProvider LithuaniaReliefMap = LithuaniaReliefMapProvider.Instance;
-        public static readonly Lithuania3dMapProvider Lithuania3dMap = Lithuania3dMapProvider.Instance;
-        public static readonly LithuaniaOrtoFotoMapProvider LithuaniaOrtoFotoMap = LithuaniaOrtoFotoMapProvider.Instance;
-        public static readonly LithuaniaOrtoFotoOldMapProvider LithuaniaOrtoFotoOldMap = LithuaniaOrtoFotoOldMapProvider.Instance;
-        public static readonly LithuaniaHybridMapProvider LithuaniaHybridMap = LithuaniaHybridMapProvider.Instance;
-        public static readonly LithuaniaHybridOldMapProvider LithuaniaHybridOldMap = LithuaniaHybridOldMapProvider.Instance;
-        public static readonly LithuaniaTOP50 LithuaniaTOP50Map = LithuaniaTOP50.Instance;
-
-        public static readonly LatviaMapProvider LatviaMap = LatviaMapProvider.Instance;
-
-        public static readonly MapBenderWMSProvider MapBenderWMSdemoMap = MapBenderWMSProvider.Instance;
-
-        public static readonly TurkeyMapProvider TurkeyMap = TurkeyMapProvider.Instance;
-
-        public static readonly CloudMadeMapProvider CloudMadeMap = CloudMadeMapProvider.Instance;
-
-        public static readonly SpainMapProvider SpainMap = SpainMapProvider.Instance;
-
-        public static readonly CzechMapProviderOld CzechOldMap = CzechMapProviderOld.Instance;
-        public static readonly CzechSatelliteMapProviderOld CzechSatelliteOldMap = CzechSatelliteMapProviderOld.Instance;
-        public static readonly CzechHybridMapProviderOld CzechHybridOldMap = CzechHybridMapProviderOld.Instance;
-        public static readonly CzechTuristMapProviderOld CzechTuristOldMap = CzechTuristMapProviderOld.Instance;
-        public static readonly CzechHistoryMapProviderOld CzechHistoryOldMap = CzechHistoryMapProviderOld.Instance;
-
-        public static readonly CzechMapProvider CzechMap = CzechMapProvider.Instance;
-        public static readonly CzechSatelliteMapProvider CzechSatelliteMap = CzechSatelliteMapProvider.Instance;
-        public static readonly CzechHybridMapProvider CzechHybridMap = CzechHybridMapProvider.Instance;
-        public static readonly CzechTuristMapProvider CzechTuristMap = CzechTuristMapProvider.Instance;
-        public static readonly CzechTuristWinterMapProvider CzechTuristWinterMap = CzechTuristWinterMapProvider.Instance;
-        public static readonly CzechHistoryMapProvider CzechHistoryMap = CzechHistoryMapProvider.Instance;
-        public static readonly CzechGeographicMapProvider CzechGeographicMap = CzechGeographicMapProvider.Instance;
-        
-        public static readonly ArcGIS_Imagery_World_2D_MapProvider ArcGIS_Imagery_World_2D_Map = ArcGIS_Imagery_World_2D_MapProvider.Instance;
-        public static readonly ArcGIS_ShadedRelief_World_2D_MapProvider ArcGIS_ShadedRelief_World_2D_Map = ArcGIS_ShadedRelief_World_2D_MapProvider.Instance;
-        public static readonly ArcGIS_StreetMap_World_2D_MapProvider ArcGIS_StreetMap_World_2D_Map = ArcGIS_StreetMap_World_2D_MapProvider.Instance;
-        public static readonly ArcGIS_Topo_US_2D_MapProvider ArcGIS_Topo_US_2D_Map = ArcGIS_Topo_US_2D_MapProvider.Instance;
-
-        public static readonly ArcGIS_World_Physical_MapProvider ArcGIS_World_Physical_Map = ArcGIS_World_Physical_MapProvider.Instance;
-        public static readonly ArcGIS_World_Shaded_Relief_MapProvider ArcGIS_World_Shaded_Relief_Map = ArcGIS_World_Shaded_Relief_MapProvider.Instance;
-        public static readonly ArcGIS_World_Street_MapProvider ArcGIS_World_Street_Map = ArcGIS_World_Street_MapProvider.Instance;
-        public static readonly ArcGIS_World_Terrain_Base_MapProvider ArcGIS_World_Terrain_Base_Map = ArcGIS_World_Terrain_Base_MapProvider.Instance;
-        public static readonly ArcGIS_World_Topo_MapProvider ArcGIS_World_Topo_Map = ArcGIS_World_Topo_MapProvider.Instance;
-
-        public static readonly ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_Map = ArcGIS_DarbAE_Q2_2011_NAVTQ_Eng_V5_MapProvider.Instance;
-
-        public static readonly SwedenMapProvider SwedenMap = SwedenMapProvider.Instance;
 
         static List<GMapProvider> list;
 

--- a/GMap.NET.Core/GMap.NET.Projections/SwissTopoProjection.cs
+++ b/GMap.NET.Core/GMap.NET.Projections/SwissTopoProjection.cs
@@ -1,0 +1,118 @@
+﻿namespace GMap.NET.Projections
+{
+    using System;
+
+    public class SwissTopoProjection : PureProjection
+    {
+        public override double Axis
+        {
+            get { return 6378137; }
+        }
+
+        public override RectLatLng Bounds
+        {
+            get { return RectLatLng.FromLTRB(MinLongitude, MaxLatitude, MaxLongitude, MinLatitude); }
+        }
+
+        public override double Flattening
+        {
+            get { return (1.0 / 298.257223563); }
+        }
+
+        public static readonly SwissTopoProjection Instance = new SwissTopoProjection();
+        static readonly double MaxLatitude = 85.05112878;
+        static readonly double MaxLongitude = 180;
+
+        static readonly double MinLatitude = -85.05112878;
+        static readonly double MinLongitude = -180;
+
+        readonly GSize tileSize = new GSize(256, 256);
+
+        public override GSize TileSize
+        {
+            get { return tileSize; }
+        }
+
+        public override GPoint FromLatLngToPixel(double lat, double lng, int zoom)
+        {
+            GPoint ret = GPoint.Empty;
+
+            lat = Clip(lat, MinLatitude, MaxLatitude);
+            lng = Clip(lng, MinLongitude, MaxLongitude);
+
+            double x = (lng + 180) / 360;
+            double sinLatitude = Math.Sin(lat * Math.PI / 180);
+            double y = 0.5 - Math.Log((1 + sinLatitude) / (1 - sinLatitude)) / (4 * Math.PI);
+
+            GSize s = GetTileMatrixSizePixel(zoom);
+            long mapSizeX = s.Width;
+            long mapSizeY = s.Height;
+
+            ret.X = (long) Clip(x * mapSizeX + 0.5, 0, mapSizeX - 1);
+            ret.Y = (long) Clip(y * mapSizeY + 0.5, 0, mapSizeY - 1);
+
+            return ret;
+        }
+
+        public override PointLatLng FromPixelToLatLng(long x, long y, int zoom)
+        {
+            PointLatLng ret = PointLatLng.Empty;
+
+            GSize s = GetTileMatrixSizePixel(zoom);
+            double mapSizeX = s.Width;
+            double mapSizeY = s.Height;
+
+            double xx = (Clip(x, 0, mapSizeX - 1) / mapSizeX) - 0.5;
+            double yy = 0.5 - (Clip(y, 0, mapSizeY - 1) / mapSizeY);
+
+            ret.Lat = 90 - 360 * Math.Atan(Math.Exp(-yy * 2 * Math.PI)) / Math.PI;
+            ret.Lng = 360 * xx;
+
+            return ret;
+        }
+
+        public override GSize GetTileMatrixMaxXY(int zoom)
+        {
+            return new GSize(TileMaxLimitsPerZoom[zoom].Width - 1, TileMaxLimitsPerZoom[zoom].Height - 1);
+        }
+
+        public override GSize GetTileMatrixMinXY(int zoom)
+        {
+            return new GSize(0, 0);
+        }
+
+        // from https://api3.geo.admin.ch/services/sdiservices.html#wmts
+        private static GSize[] TileMaxLimitsPerZoom = new GSize[]
+        {
+            new GSize(1, 1), /* zoom = 0 */
+            new GSize(1, 1), /* zoom = 1 */
+            new GSize(1, 1), /* zoom = 2 */
+            new GSize(1, 1), /* zoom = 3 */
+            new GSize(1, 1), /* zoom = 4 */
+            new GSize(1, 1), /* zoom = 5 */
+            new GSize(1, 1), /* zoom = 6 */
+            new GSize(1, 1), /* zoom = 7 */
+            new GSize(1, 1), /* zoom = 8 */
+            new GSize(2, 1), /* zoom = 9 */
+            new GSize(2, 1), /* zoom = 10 */
+            new GSize(2, 1), /* zoom = 11 */
+            new GSize(2, 2), /* zoom = 12 */
+            new GSize(3, 2), /* zoom = 13 */
+            new GSize(3, 2), /* zoom = 14 */
+            new GSize(4, 3), /* zoom = 15 */
+            new GSize(8, 5), /* zoom = 16 */
+            new GSize(19, 13), /* zoom = 17 */
+            new GSize(38, 25), /* zoom = 18 */
+            new GSize(94, 63), /* zoom = 19 */
+            new GSize(188, 125), /* zoom = 20 */
+            new GSize(375, 250), /* zoom = 21 */
+            new GSize(750, 500), /* zoom = 22 */
+            new GSize(938, 625), /* zoom = 23 */
+            new GSize(1250, 834), /* zoom = 24 */
+            new GSize(1875, 1250), /* zoom = 25 */
+            new GSize(3750, 2500), /* zoom = 26 */
+            new GSize(7500, 5000), /* zoom = 27 */
+            new GSize(18750, 12500), /* zoom = 28 */
+        };
+    }
+}


### PR DESCRIPTION
1. New SwissTopo provider added, based on specs from https://api3.geo.admin.ch/services/sdiservices.html#wmts .
2. SwissTopoProjection.cs inspired from the MercatorProjection, just that the tile limits for each zoom are customized
3. Sorted in ascending order the map providers