### PR TITLE
Fix OnMouseDoubleClick bug

### DIFF
--- a/GMap.NET.WindowsForms/GMap.NET.WindowsForms/GMapControl.cs
+++ b/GMap.NET.WindowsForms/GMap.NET.WindowsForms/GMapControl.cs
@@ -1938,7 +1938,7 @@ namespace GMap.NET.WindowsForms
 
         protected override void OnMouseDoubleClick(MouseEventArgs e)
         {
-            base.OnMouseClick(e);
+            base.OnMouseDoubleClick(e);
 
             if (!Core.IsDragging)
             {


### PR DESCRIPTION
when OnMouseDoubleClick overrided, it called base.OnMouseClick wrongly.
Replace Call base.OnMouseDoubleClick  instead of base.OnMouseClick